### PR TITLE
Add new client constructor to support MTLS

### DIFF
--- a/hubclient/client.go
+++ b/hubclient/client.go
@@ -17,9 +17,11 @@ package hubclient
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
@@ -100,7 +102,8 @@ func NewWithTokenTLS(baseURL string, authToken string, debugFlags HubClientDebug
 
 	caCert, err := ioutil.ReadFile(cacert)
 	if err != nil {
-		log.Fatal(err)
+		log.Warnf("Cannot read caCert file")
+		return nil, err
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)

--- a/hubclient/client.go
+++ b/hubclient/client.go
@@ -116,6 +116,20 @@ func readBytes(readCloser io.ReadCloser) ([]byte, error) {
 
 func validateHTTPResponse(resp *http.Response, expectedStatusCode int) error {
 
+	// TODO: This is a hack, I need to fix this.
+	if expectedStatusCode == 0 {
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		}
+
+		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+			log.Warnf("Got a %d response, this indicate a redirect may need to be followed.", resp.StatusCode)
+			return nil
+		}
+
+		return fmt.Errorf("Got a status code of: %d. Expected a successful status code.", resp.StatusCode)
+	}
+
 	if resp.StatusCode != expectedStatusCode { // Should this be a list at some point?
 		log.Errorf("Got a %d response instead of a %d.", resp.StatusCode, expectedStatusCode)
 		readResponseBody(resp)


### PR DESCRIPTION
Blackduck service to service communication will be done through mutual TLS. To work with that we need a new blackduck client with the MTLS support.