### PR TITLE
add error context to help with debugging

### DIFF
--- a/hubclient/scanclient-client.go
+++ b/hubclient/scanclient-client.go
@@ -41,7 +41,7 @@ func (c *Client) downloadScanClientHelper(path string, urlPath string) error {
 
 	resp, err := c.httpClient.Get(scanClientURL)
 	if err != nil {
-		return errors.Annotate(err, "unable to http GET")
+		return errors.Annotatef(err, "unable to http GET %s", urlPath)
 	} else if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("GET failed: received status != 200 from %s: %s", scanClientURL, resp.Status)
 	}


### PR DESCRIPTION
`errors.Annotatef` returns nil when its `err` arg is nil.