### PR TITLE
Add ability to fetch component remediation information 

### DIFF
--- a/hubapi/component-api.go
+++ b/hubapi/component-api.go
@@ -95,3 +95,17 @@ type ComponentRequest struct {
 	ApprovalStatus      string   `json:"approvalStatus"`
 	Type                string   `json:"type"`
 }
+
+type ComponentRemediation struct {
+	FixesPreviousVulnerabilities RemediationInfo `json:"fixesPreviousVulnerabilities,omitempty"`
+	NoVulnerabilities            RemediationInfo `json:"noVulnerabilities,omitempty"`
+	LatestAfterCurrent           RemediationInfo `json:"latestAfterCurrent,omitempty"`
+	Meta                         Meta            `json:"_meta"`
+}
+
+type RemediationInfo struct {
+	ComponentVersion   string `json:"componentVersion"`
+	Name               string `json:"name"`
+	ReleasedOn         string `json:"releasedOn"`
+	VulnerabilityCount int    `json:"vulnerabilityCount"`
+}

--- a/hubclient/component-client.go
+++ b/hubclient/component-client.go
@@ -21,6 +21,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	remediatingApi = "/remediating"
+)
+
 func (c *Client) ListComponents(options *hubapi.GetListOptions) (*hubapi.ComponentList, error) {
 	params := ""
 	if options != nil {
@@ -85,4 +89,14 @@ func (c *Client) GetComponentVersion(link *hubapi.ResourceLink) (*hubapi.Compone
 
 func (c *Client) GetComponentVersionFromVariant(componentVariant *hubapi.ComponentVariant) (*hubapi.ComponentVersion, error) {
 	return c.GetComponentVersion(&hubapi.ResourceLink{Href: componentVariant.Version})
+}
+
+func (c *Client) GetRemediationForComponentVersion(componentVersion *hubapi.ComponentVersion) (*hubapi.ComponentRemediation, error) {
+	var componentRemediation hubapi.ComponentRemediation
+	err := c.HttpGetJSON(componentVersion.Meta.Href+remediatingApi, &componentRemediation, 200)
+	if err != nil {
+		log.Errorf("Error trying to retrieve component remediation: %+v.", err)
+		return nil, err
+	}
+	return &componentRemediation, nil
 }

--- a/hubclient/component-client_test.go
+++ b/hubclient/component-client_test.go
@@ -77,3 +77,27 @@ func TestClient_GetComponentVersionFromVariant(t *testing.T) {
 	assert.NotEmpty(t, componentVersion.Meta.Href)
 	assert.True(t, len(componentVersion.Meta.Allow) > 0)
 }
+
+func TestClient_GetComponentRemediation(t *testing.T) {
+
+	client := createTestClient(t)
+	assert.NotNil(t, client, "unable to get client")
+
+	option := "maven:org.apache.commons:commons-collections4:4.0"
+	listOptions := &hubapi.GetListOptions{Q: &option}
+
+	componentList, err := client.ListComponents(listOptions)
+	assert.NoError(t, err)
+	assert.True(t, len(componentList.Items) > 0, "Expected at least one componentlist item")
+
+	componentVariant := componentList.Items[0]
+
+	componentVersion, err := client.GetComponentVersionFromVariant(&componentVariant)
+	assert.NoError(t, err)
+
+	remediation, err := client.GetRemediationForComponentVersion(componentVersion)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, remediation.NoVulnerabilities.Name)
+	assert.NotEmpty(t, remediation.LatestAfterCurrent.Name)
+	assert.NotEmpty(t, remediation.FixesPreviousVulnerabilities.Name)
+}


### PR DESCRIPTION
This URL is not currently included in the component version links so is built via the component version href.