### PR TITLE
Handle cases where 'data' is not a string or integer type while consuming policy-rules of a BOM component API

### DIFF
--- a/hubapi/policyrules-api.go
+++ b/hubapi/policyrules-api.go
@@ -15,8 +15,6 @@
 package hubapi
 
 import (
-	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
 	"time"
@@ -66,7 +64,7 @@ type Expression struct {
 
 type ExpressionParameter struct {
 	Values []string                 `json:"values"`
-	Data   []map[string]IntOrString `json:"data"`
+	Data   []map[string]interface{} `json:"data"`
 }
 
 type PolicyRuleRequest struct {
@@ -79,38 +77,12 @@ type PolicyRuleRequest struct {
 	Severity    string           `json:"severity"`
 }
 
-type IntOrString struct {
-	Type   Type   `json:"type"`
-	IntVal int32  `json:"intVal"`
-	StrVal string `json:"strVal"`
-}
-
 type Type int
 
 const (
 	Int    Type = iota // The IntOrString holds an int.
 	String             // The IntOrString holds a string.
 )
-
-func (intstr *IntOrString) UnmarshalJSON(value []byte) error {
-	if value[0] == '"' {
-		intstr.Type = String
-		return json.Unmarshal(value, &intstr.StrVal)
-	}
-	intstr.Type = Int
-	return json.Unmarshal(value, &intstr.IntVal)
-}
-
-func (intstr IntOrString) MarshalJSON() ([]byte, error) {
-	switch intstr.Type {
-	case Int:
-		return json.Marshal(intstr.IntVal)
-	case String:
-		return json.Marshal(intstr.StrVal)
-	default:
-		return []byte{}, fmt.Errorf("impossible IntOrString.Type")
-	}
-}
 
 func (pr *PolicyRule) IsEqual(obj *PolicyRule) bool {
 	if !strings.EqualFold(pr.Name, obj.Name) {

--- a/hubapi/policyrules-api_test.go
+++ b/hubapi/policyrules-api_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Synopsys, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubapi
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePolicyRulesBOMComponent(t *testing.T) {
+	content, err := ioutil.ReadFile("testdata/policyRulesBOMComponent.json")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, content)
+
+	policyRules := BomComponentPolicyRulesList{}
+	err = json.Unmarshal(content, &policyRules)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, policyRules.TotalCount)
+	assert.Len(t, policyRules.Items, 2)
+
+	rule := policyRules.Items[1]
+	assert.NotEmpty(t, rule.CreatedAt)
+	assert.Len(t, rule.Expression.Expressions, 2)
+
+	expression := rule.Expression.Expressions[0]
+	assert.Equal(t, "HIGH_SEVERITY_VULN_COUNT", expression.Name)
+	assert.Len(t, expression.Parameters.Values, 1)
+	assert.Equal(t, "0", expression.Parameters.Values[0])
+	assert.Len(t, expression.Parameters.Data, 1)
+	assert.Equal(t, float64(0), expression.Parameters.Data[0]["data"])
+
+	expression = rule.Expression.Expressions[1]
+	assert.Equal(t, "VULN_LEVEL_EXPLOIT", expression.Name)
+	assert.Len(t, expression.Parameters.Values, 1)
+	assert.Equal(t, "TRUE", expression.Parameters.Values[0])
+	assert.Len(t, expression.Parameters.Data, 1)
+	assert.Equal(t, true, expression.Parameters.Data[0]["data"])
+}

--- a/hubapi/testdata/policyRulesBOMComponent.json
+++ b/hubapi/testdata/policyRulesBOMComponent.json
@@ -1,0 +1,115 @@
+{
+  "totalCount": 2,
+  "items": [
+    {
+      "name": "Apache Ant",
+      "enabled": true,
+      "overridable": true,
+      "severity": "MAJOR",
+      "expression": {
+        "operator": "AND",
+        "expressions": [
+          {
+            "name": "SINGLE_VERSION",
+            "operation": "EQ",
+            "parameters": {
+              "values": [
+                "https://localhost/api/components/b3f578fd-f966-4953-9a8d-6cb28323e7d4/versions/e80b2e6d-1506-4639-80f6-fa9945e9af6e"
+              ],
+              "data": [
+                {
+                  "componentName": "Apache Ant",
+                  "componentUrl": "https://localhost/api/components/b3f578fd-f966-4953-9a8d-6cb28323e7d4",
+                  "componentVersionName": "1.7.1",
+                  "componentVersionUrl": "https://localhost/api/components/b3f578fd-f966-4953-9a8d-6cb28323e7d4/versions/e80b2e6d-1506-4639-80f6-fa9945e9af6e"
+                }
+              ]
+            },
+            "displayName": "Component"
+          }
+        ]
+      },
+      "createdAt": "2020-05-20T22:18:59.086Z",
+      "createdBy": "demo",
+      "createdByUser": "https://localhost/api/users/1f2ddd68-001e-4f63-8212-4286d987527e",
+      "updatedAt": "2020-05-20T22:18:59.086Z",
+      "updatedBy": "demo",
+      "updatedByUser": "https://localhost/api/users/1f2ddd68-001e-4f63-8212-4286d987527e",
+      "policyApprovalStatus": "IN_VIOLATION",
+      "_meta": {
+        "allow": [
+          "DELETE",
+          "GET",
+          "PUT"
+        ],
+        "href": "https://localhost/api/policy-rules/e1a48b5c-ca7e-4120-adde-0357d9ee42ac",
+        "links": []
+      }
+    },
+    {
+      "name": "No High Exploitable Vuns",
+      "enabled": true,
+      "overridable": true,
+      "severity": "MAJOR",
+      "expression": {
+        "operator": "AND",
+        "expressions": [
+          {
+            "name": "HIGH_SEVERITY_VULN_COUNT",
+            "operation": "GT",
+            "parameters": {
+              "values": [
+                "0"
+              ],
+              "data": [
+                {
+                  "data": 0
+                }
+              ]
+            },
+            "displayName": "High Severity Vulnerability Count"
+          },
+          {
+            "name": "VULN_LEVEL_EXPLOIT",
+            "operation": "EQ",
+            "parameters": {
+              "values": [
+                "TRUE"
+              ],
+              "data": [
+                {
+                  "data": true
+                }
+              ]
+            },
+            "displayName": "Exploit Available"
+          }
+        ]
+      },
+      "createdAt": "2020-01-21T18:35:57.080Z",
+      "createdBy": "demo",
+      "createdByUser": "https://localhost/api/users/1f2ddd68-001e-4f63-8212-4286d987527e",
+      "updatedAt": "2020-05-01T10:54:38.963Z",
+      "updatedBy": "demo",
+      "updatedByUser": "https://localhost/api/users/1f2ddd68-001e-4f63-8212-4286d987527e",
+      "policyApprovalStatus": "IN_VIOLATION",
+      "_meta": {
+        "allow": [
+          "DELETE",
+          "GET",
+          "PUT"
+        ],
+        "href": "https://localhost/api/policy-rules/74bf8e72-0a7e-464a-ac23-cc946d3f4e92",
+        "links": []
+      }
+    }
+  ],
+  "appliedFilters": [],
+  "_meta": {
+    "allow": [
+      "GET"
+    ],
+    "href": "https://localhost/api/projects/9f7a0dd9-4137-42cc-a59e-9d0abe85561a/versions/a06b9064-d14e-4bba-ae51-dc94cf54e27d/components/b3f578fd-f966-4953-9a8d-6cb28323e7d4/versions/e80b2e6d-1506-4639-80f6-fa9945e9af6e/policy-rules",
+    "links": []
+  }
+}


### PR DESCRIPTION
Handle cases where 'data' is not a string or integer type while consuming policy-rules of a BOM component API

Addresses https://github.com/blackducksoftware/hub-client-go/issues/55

After talking to the hub team, it appears that assuming `PolicyRule.Expression.ExpressionParameter.Data` to be a `map[string]IntOrString` type was incorrect.

`PolicyRule.Expression.ExpressionParameter.Data` is a dynamic JSON object whose contents are dependent on the details of the policy. Changing the type to be a map[string]interface{} should fix this issue.

Also `PolicyRule.Expression.ExpressionParameter.Data` is not mentioned in the hub api docs. There's a separate bug tracking this.