### PR TITLE
BDOA-87. Fix nil pointer issue

### DIFF
--- a/hubclient/client.go
+++ b/hubclient/client.go
@@ -181,9 +181,12 @@ func (c *Client) processResponse(resp *http.Response, result interface{}, expect
 
 func (c *Client) HttpGetString(url string, result *string, expectedStatusCode []int, mimetypes ...string) (error, int) {
 	err, response := c.httpGet(url, nil, expectedStatusCode, mimetypes...)
+
+	statusCode := getResponseStatus(response)
 	body := readResponseBody(response, c.debugFlags)
 	*result = string(body)
-	return err, response.StatusCode
+
+	return err, statusCode
 }
 
 func (c *Client) HttpGetJSON(url string, result interface{}, expectedStatusCode int, mimetypes ...string) error {
@@ -505,6 +508,15 @@ func (c *Client) GetPage(link string, options *hubapi.GetListOptions, list inter
 	}
 
 	return nil
+}
+
+func getResponseStatus(resp *http.Response) int {
+	statusCode := 0
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+
+	return statusCode
 }
 
 func readResponseBody(resp *http.Response, debugFlags HubClientDebug) (bodyBytes []byte) {


### PR DESCRIPTION
In hubclient.HttpGetString, response may be nil in case of an error. This results in "runtime error: invalid memory address or nil pointer dereference". This PR handles this case, by returning 0 status when response is nil.