### PR TITLE
Cache auth-token expiry and  use cached hub url in health-check APIs

### DIFF
--- a/hubclient/client.go
+++ b/hubclient/client.go
@@ -41,6 +41,8 @@ type Client struct {
 	csrfToken       string
 	debugFlags      HubClientDebug
 	headerOverrides http.Header
+	// Unix time in seconds at which the authToken expires
+	authTokenExpiryInUnixSec int64
 }
 
 func NewWithSession(baseURL string, debugFlags HubClientDebug, timeout time.Duration) (*Client, error) {
@@ -564,4 +566,13 @@ func newHubClientError(respBody []byte, resp *http.Response, message string, und
 	}
 
 	return hce
+}
+
+// GetAuthTokenExpiryTime returns the unix time in seconds at which the cached auth token is set to expire
+// This func returns -1 if the Client is not configured to use auth token
+func (c *Client) GetAuthTokenExpiryTime() int64 {
+	if c == nil || !c.useAuthToken || c.authToken == "" {
+		return -1
+	}
+	return c.authTokenExpiryInUnixSec
 }

--- a/hubclient/health-check-client.go
+++ b/hubclient/health-check-client.go
@@ -21,13 +21,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (c *Client) CheckHubReadiness(hubUrl string) (error, *hubapi.HealthCheckStatus) {
-	readinessUrl := hubapi.BuildUrl(hubUrl, hubapi.ReadinessApi)
+func (c *Client) CheckHubReadiness() (error, *hubapi.HealthCheckStatus) {
+	readinessUrl := hubapi.BuildUrl(c.BaseURL(), hubapi.ReadinessApi)
 	return checkHealthStatus(c, readinessUrl)
 }
 
-func (c *Client) CheckHubLiveness(hubUrl string) (error, *hubapi.HealthCheckStatus) {
-	livenessUrl := hubapi.BuildUrl(hubUrl, hubapi.LivenessApi)
+func (c *Client) CheckHubLiveness() (error, *hubapi.HealthCheckStatus) {
+	livenessUrl := hubapi.BuildUrl(c.BaseURL(), hubapi.LivenessApi)
 	return checkHealthStatus(c, livenessUrl)
 }
 

--- a/hubclient/rapid-scans-client.go
+++ b/hubclient/rapid-scans-client.go
@@ -133,7 +133,7 @@ func (c *Client) PollRapidScanResults(rapidScanEndpoint string, interval, timeou
 func (c *Client) FetchResults(rapidScanEndpoint string, offset int, pageLimit int) (err error, httpStatus int, result *hubapi.RapidScanResult) {
 	var body string
 	err, statusCode := c.fetchResults(rapidScanEndpoint, 0, 1, &body)
-	if err != nil  || statusCode != http.StatusOK{
+	if err != nil || statusCode != http.StatusOK {
 		return err, statusCode, nil
 	}
 	err, result = parseBody(body)


### PR DESCRIPTION
In this MR:

- While initializing the client with api-token, compute the expiry time of the generated bearer token and cache it
- Use cached hub url to perform health checks.