### PR TITLE
Remove additional header field caching 

### DIFF
--- a/hubclient/apitoken-client.go
+++ b/hubclient/apitoken-client.go
@@ -17,11 +17,11 @@ package hubclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/blackducksoftware/hub-client-go/hubapi"
 	"io/ioutil"
 	"net/http"
 	"time"
 
+	"github.com/blackducksoftware/hub-client-go/hubapi"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -98,7 +98,6 @@ func NewWithApiTokenAndClient(baseURL string, apiToken string, debugFlags HubCli
 		csrfToken:                csrf,
 		haveCsrfToken:            true,
 		debugFlags:               debugFlags,
-		headerOverrides:          http.Header{},
 		authTokenExpiryInUnixSec: bearerTokenExpiryTime.Unix(),
 	}, nil
 }

--- a/hubclient/client.go
+++ b/hubclient/client.go
@@ -33,16 +33,16 @@ import (
 
 // Client will need to support CSRF tokens for session-based auth for Hub 4.1.x (or was it 4.0?)
 type Client struct {
-	httpClient      *http.Client
-	baseURL         string
-	authToken       string
-	useAuthToken    bool
-	haveCsrfToken   bool
-	csrfToken       string
-	debugFlags      HubClientDebug
-	headerOverrides http.Header
+	httpClient    *http.Client
+	baseURL       string
+	authToken     string
+	useAuthToken  bool
+	haveCsrfToken bool
+	csrfToken     string
+	debugFlags    HubClientDebug
 	// Unix time in seconds at which the authToken expires
 	authTokenExpiryInUnixSec int64
+	userAgent                string
 }
 
 func NewWithSession(baseURL string, debugFlags HubClientDebug, timeout time.Duration) (*Client, error) {
@@ -67,11 +67,10 @@ func NewWithClient(baseURL string, debugFlags HubClientDebug, httpClient *http.C
 	}
 
 	return &Client{
-		httpClient:      httpClient,
-		baseURL:         baseURL,
-		useAuthToken:    false,
-		debugFlags:      debugFlags,
-		headerOverrides: http.Header{},
+		httpClient:   httpClient,
+		baseURL:      baseURL,
+		useAuthToken: false,
+		debugFlags:   debugFlags,
 	}, nil
 }
 
@@ -86,12 +85,11 @@ func NewWithTokenAndClient(baseURL string, authToken string, debugFlags HubClien
 	}
 
 	return &Client{
-		httpClient:      httpClient,
-		baseURL:         baseURL,
-		authToken:       authToken,
-		useAuthToken:    true,
-		debugFlags:      debugFlags,
-		headerOverrides: http.Header{},
+		httpClient:   httpClient,
+		baseURL:      baseURL,
+		authToken:    authToken,
+		useAuthToken: true,
+		debugFlags:   debugFlags,
 	}, nil
 }
 
@@ -209,7 +207,7 @@ func (c *Client) httpGet(url string, result interface{}, expectedStatusCodes []i
 		return newHubClientError(nil, nil, fmt.Sprintf("error creating http get request for %s: %+v", url, err), err), resp
 	}
 
-	c.applyHeaderValues(req)
+	c.applyHeaderValues(req, nil)
 
 	if len(mimetypes) > 0 {
 		for _, mimetype := range mimetypes {
@@ -239,12 +237,16 @@ func (c *Client) httpGet(url string, result interface{}, expectedStatusCodes []i
 }
 
 func (c *Client) HttpPutString(url string, data string, contentType string, expectedStatusCode int) error {
+	return c.HttpPutStringWithHeader(url, data, contentType, expectedStatusCode, nil)
+}
+
+func (c *Client) HttpPutStringWithHeader(url string, data string, contentType string, expectedStatusCode int, header http.Header) error {
 	if c.debugFlags&HubClientDebugTimings != 0 {
 		log.Debugf("DEBUG HTTP STARTING %s STRING REQUEST: %s", http.MethodPut, url)
 	}
 
 	reader := strings.NewReader(data)
-	return c.putRequest(url, reader, contentType, expectedStatusCode)
+	return c.putRequestWithHeader(url, reader, contentType, expectedStatusCode, header)
 }
 
 func (c *Client) HttpPutJSON(url string, data interface{}, contentType string, expectedStatusCode int) error {
@@ -264,6 +266,10 @@ func (c *Client) HttpPutJSON(url string, data interface{}, contentType string, e
 }
 
 func (c *Client) putRequest(url string, reader io.Reader, contentType string, expectedStatusCode int) error {
+	return c.putRequestWithHeader(url, reader, contentType, expectedStatusCode, nil)
+}
+
+func (c *Client) putRequestWithHeader(url string, reader io.Reader, contentType string, expectedStatusCode int, header http.Header) error {
 	req, err := http.NewRequest(http.MethodPut, url, reader)
 	if err != nil {
 		return newHubClientError(nil, nil, fmt.Sprintf("error creating http put request for %s: %+v", url, err), err)
@@ -271,7 +277,7 @@ func (c *Client) putRequest(url string, reader io.Reader, contentType string, ex
 
 	req.Header.Set(HeaderNameContentType, contentType)
 
-	c.applyHeaderValues(req)
+	c.applyHeaderValues(req, header)
 	log.Debugf("PUT Request: %+v.", req)
 
 	httpStart := time.Now()
@@ -322,7 +328,7 @@ func (c *Client) postRequest(url string, reader io.Reader, contentType string, e
 
 	req.Header.Set(HeaderNameContentType, contentType)
 
-	c.applyHeaderValues(req)
+	c.applyHeaderValues(req, nil)
 
 	log.Debugf("POST Request: %+v.", req)
 
@@ -369,7 +375,7 @@ func (c *Client) HttpPostJSONExpectResult(url string, data interface{}, result i
 
 	req.Header.Set(HeaderNameContentType, contentType)
 
-	c.applyHeaderValues(req)
+	c.applyHeaderValues(req, nil)
 
 	log.Debugf("POST Request: %+v.", req)
 
@@ -407,7 +413,7 @@ func (c *Client) HttpDelete(url string, contentType string, expectedStatusCode i
 
 	req.Header.Set(HeaderNameContentType, contentType)
 
-	c.applyHeaderValues(req)
+	c.applyHeaderValues(req, nil)
 
 	log.Debugf("DELETE Request: %+v.", req)
 
@@ -427,8 +433,8 @@ func (c *Client) HttpDelete(url string, contentType string, expectedStatusCode i
 }
 
 // Applies authentication headers (see setAuthHeaders) and also applies any custom header values to the provided request
-func (c *Client) applyHeaderValues(request *http.Request) {
-	for key, values := range c.headerOverrides {
+func (c *Client) applyHeaderValues(request *http.Request, header http.Header) {
+	for key, values := range header {
 		// remove any old values in the provided request header
 		request.Header.Del(key)
 		for _, value := range values {
@@ -437,6 +443,11 @@ func (c *Client) applyHeaderValues(request *http.Request) {
 		}
 
 	}
+
+	if c.userAgent != "" {
+		request.Header.Add("User-Agent", c.userAgent)
+	}
+
 	c.setAuthHeaders(request)
 }
 
@@ -478,21 +489,6 @@ func (c *Client) ForEachPage(link string, listOptions *hubapi.GetListOptions, li
 	}
 
 	return err
-}
-
-// Sets header override values for the provided key for any subsequent requests by this client
-func (c *Client) SetHeaderValue(key string, value string) {
-	c.headerOverrides.Set(key, value)
-}
-
-// Clears a previously set header override value for this client
-func (c *Client) DeleteHeaderValue(key string) {
-	c.headerOverrides.Del(key)
-}
-
-// Adds header override values for the provided key for any subsequent requests by this client
-func (c *Client) AddHeaderValue(key string, value string) {
-	c.headerOverrides.Add(key, value)
 }
 
 func resetList(v interface{}) {
@@ -575,4 +571,9 @@ func (c *Client) GetAuthTokenExpiryTime() int64 {
 		return -1
 	}
 	return c.authTokenExpiryInUnixSec
+}
+
+// Sets the User-Agent header value to be used in all http/https requests made by the client
+func (c *Client) SetUserAgent(agent string) {
+	c.userAgent = agent
 }

--- a/hubclient/client.go
+++ b/hubclient/client.go
@@ -445,7 +445,7 @@ func (c *Client) applyHeaderValues(request *http.Request, header http.Header) {
 	}
 
 	if c.userAgent != "" {
-		request.Header.Add("User-Agent", c.userAgent)
+		request.Header.Add(HeaderNameUserAgent, c.userAgent)
 	}
 
 	c.setAuthHeaders(request)

--- a/hubclient/client_test.go
+++ b/hubclient/client_test.go
@@ -16,13 +16,11 @@ package hubclient
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/blackducksoftware/hub-client-go/hubapi"
 	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestFetchPolicyStatus is a very brittle test because it requires:
@@ -75,42 +73,4 @@ func TestCreateAndDeleteProject(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-}
-
-func TestAddClearHeaders(t *testing.T) {
-	apiCurrentUser := "/api/current-user"
-	client, err := NewWithSession("https://localhost", HubClientDebugTimings, 5*time.Second)
-	if err != nil {
-		t.Error(err)
-	}
-	err = client.Login("sysadmin", "blackduck")
-	if err != nil {
-		t.Error(err)
-	}
-	// set a couple header values
-	client.SetHeaderValue("User-Agent", "go_api_client_test")
-	client.SetHeaderValue("Another-Header-Key", "another value")
-
-	//create a request
-	req, err := http.NewRequest(http.MethodGet, client.baseURL+apiCurrentUser, nil)
-	assert.NoError(t, err)
-
-	// apply the new header values to the request
-	client.applyHeaderValues(req)
-
-	assert.Equal(t, "go_api_client_test", req.Header.Get("User-Agent"))
-	assert.Equal(t, "another value", req.Header.Get("Another-Header-Key"))
-
-	// clear the user agent extra header value
-	client.DeleteHeaderValue("User-Agent")
-
-	// create a new request
-	req, err = http.NewRequest(http.MethodGet, client.baseURL+apiCurrentUser, nil)
-	assert.NoError(t, err)
-
-	// apply the header values
-	client.applyHeaderValues(req)
-
-	assert.Empty(t, req.Header.Get("User-Agent"))
-	assert.Equal(t, "another value", req.Header.Get("Another-Header-Key"))
 }

--- a/hubclient/constants.go
+++ b/hubclient/constants.go
@@ -19,4 +19,5 @@ const (
 	HeaderNameAccept        = "Accept"
 	HeaderNameAuthorization = "Authorization"
 	HeaderNameCsrfToken     = "X-Csrf-Token"
+	HeaderNameUserAgent     = "User-Agent"
 )

--- a/hubclient/rapid-scans-client.go
+++ b/hubclient/rapid-scans-client.go
@@ -46,26 +46,24 @@ func (c *Client) StartRapidScan(bdioHeaderContent string) (error, string) {
 }
 
 func (c *Client) UploadBdioFiles(bdioUploadEndpoint string, bdioContents []string) error {
-	c.AddHeaderValue(headerBdMode, bdModeAppend)
-	c.AddHeaderValue(headerBdDocumentCount, strconv.Itoa(len(bdioContents)))
+	header := http.Header{}
+	header.Add(headerBdMode, bdModeAppend)
+	header.Add(headerBdDocumentCount, strconv.Itoa(len(bdioContents)))
 
 	for _, bdioContent := range bdioContents {
-		err := c.HttpPutString(bdioUploadEndpoint, bdioContent, hubapi.ContentTypeRapidScanRequest, http.StatusAccepted)
+		err := c.HttpPutStringWithHeader(bdioUploadEndpoint, bdioContent, hubapi.ContentTypeRapidScanRequest, http.StatusAccepted, header)
 		if err != nil {
 			log.Error("Error uploading bdio files.", err)
 			return err
 		}
 	}
 
-	c.SetHeaderValue(headerBdMode, bdModeFinish)
-	err := c.HttpPutString(bdioUploadEndpoint, "", hubapi.ContentTypeRapidScanRequest, http.StatusAccepted)
+	header.Set(headerBdMode, bdModeFinish)
+	err := c.HttpPutStringWithHeader(bdioUploadEndpoint, "", hubapi.ContentTypeRapidScanRequest, http.StatusAccepted, header)
 	if err != nil {
 		log.Error("Error uploading bdio files.", err)
 		return err
 	}
-
-	c.DeleteHeaderValue(headerBdMode)
-	c.DeleteHeaderValue(headerBdDocumentCount)
 
 	return nil
 }


### PR DESCRIPTION
Remove additional header field caching as concurrent modifications can cause API calls to fail.

Added a field for User-Agent which will still apply to headers but should not cause failures if concurrent modifications were occurring for some reason.