### PR TITLE
upload bdio files one chunk at a time

### DIFF
--- a/hubclient/array-chunk-iterator.go
+++ b/hubclient/array-chunk-iterator.go
@@ -1,5 +1,7 @@
 package hubclient
 
+import "github.com/pkg/errors"
+
 type ArrayChunkIterator struct {
 	chunks   []string
 	position int
@@ -21,10 +23,10 @@ func (i *ArrayChunkIterator) hasNext() bool {
 }
 
 // next returns true and the next chunk if there is a next chunk. Returns false otherwise.
-func (i *ArrayChunkIterator) next() (string, bool) {
+func (i *ArrayChunkIterator) next() (string, error) {
 	i.position++
 	if i.position < len(i.chunks) {
-		return i.chunks[i.position], true
+		return i.chunks[i.position], nil
 	}
-	return "", false
+	return "", errors.New("A new chunk was requested but no chunks exist.")
 }

--- a/hubclient/array-chunk-iterator.go
+++ b/hubclient/array-chunk-iterator.go
@@ -13,14 +13,18 @@ func NewArrayChunkIterator(chunks []string) ArrayChunkIterator {
 }
 
 func (i *ArrayChunkIterator) hasNext() bool {
-	if len(i.chunks) < (i.position + 1) {
+	if len(i.chunks) > (i.position + 1) {
 		return true
 	} else {
 		return false
 	}
 }
 
-func (i *ArrayChunkIterator) next() string {
+// next returns true and the next chunk if there is a next chunk. Returns false otherwise.
+func (i *ArrayChunkIterator) next() (string, bool) {
 	i.position++
-	return i.chunks[i.position]
+	if i.position < len(i.chunks) {
+		return i.chunks[i.position], true
+	}
+	return "", false
 }

--- a/hubclient/array-chunk-iterator.go
+++ b/hubclient/array-chunk-iterator.go
@@ -1,0 +1,26 @@
+package hubclient
+
+type ArrayChunkIterator struct {
+	chunks   []string
+	position int
+}
+
+func NewArrayChunkIterator(chunks []string) ArrayChunkIterator {
+	i := new(ArrayChunkIterator)
+	i.chunks = chunks
+	i.position = -1
+	return *i
+}
+
+func (i *ArrayChunkIterator) hasNext() bool {
+	if len(i.chunks) < (i.position + 1) {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (i *ArrayChunkIterator) next() string {
+	i.position++
+	return i.chunks[i.position]
+}

--- a/hubclient/array-chunk-iterator_test.go
+++ b/hubclient/array-chunk-iterator_test.go
@@ -1,6 +1,7 @@
 package hubclient
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -49,10 +50,10 @@ func TestArrayChunkIterator_next(t *testing.T) {
 		position int
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   string
-		want1  bool
+		name    string
+		fields  fields
+		want    string
+		wantErr assert.ErrorAssertionFunc
 	}{
 		{
 			name: "Test get existing next",
@@ -60,8 +61,8 @@ func TestArrayChunkIterator_next(t *testing.T) {
 				chunks:   []string{"chunk1", "chunk2"},
 				position: 0,
 			},
-			want:  "chunk2",
-			want1: true,
+			want:    "chunk2",
+			wantErr: assert.NoError,
 		},
 		{
 			name: "Test fail when there is no next",
@@ -69,8 +70,8 @@ func TestArrayChunkIterator_next(t *testing.T) {
 				chunks:   []string{"chunk1", "chunk2"},
 				position: 1,
 			},
-			want:  "",
-			want1: false,
+			want:    "",
+			wantErr: assert.Error,
 		},
 	}
 	for _, tt := range tests {
@@ -79,9 +80,11 @@ func TestArrayChunkIterator_next(t *testing.T) {
 				chunks:   tt.fields.chunks,
 				position: tt.fields.position,
 			}
-			got, got1 := i.next()
+			got, err := i.next()
+			if !tt.wantErr(t, err, fmt.Sprintf("next()")) {
+				return
+			}
 			assert.Equalf(t, tt.want, got, "next()")
-			assert.Equalf(t, tt.want1, got1, "next()")
 		})
 	}
 }

--- a/hubclient/array-chunk-iterator_test.go
+++ b/hubclient/array-chunk-iterator_test.go
@@ -1,0 +1,70 @@
+package hubclient
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestArrayChunkIterator_hasNext(t *testing.T) {
+	type fields struct {
+		chunks   []string
+		position int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &ArrayChunkIterator{
+				chunks:   tt.fields.chunks,
+				position: tt.fields.position,
+			}
+			assert.Equalf(t, tt.want, i.hasNext(), "hasNext()")
+		})
+	}
+}
+
+func TestArrayChunkIterator_next(t *testing.T) {
+	type fields struct {
+		chunks   []string
+		position int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &ArrayChunkIterator{
+				chunks:   tt.fields.chunks,
+				position: tt.fields.position,
+			}
+			assert.Equalf(t, tt.want, i.next(), "next()")
+		})
+	}
+}
+
+func TestNewArrayChunkIterator(t *testing.T) {
+	type args struct {
+		chunks []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want ArrayChunkIterator
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, NewArrayChunkIterator(tt.args.chunks), "NewArrayChunkIterator(%v)", tt.args.chunks)
+		})
+	}
+}

--- a/hubclient/array-chunk-iterator_test.go
+++ b/hubclient/array-chunk-iterator_test.go
@@ -15,7 +15,22 @@ func TestArrayChunkIterator_hasNext(t *testing.T) {
 		fields fields
 		want   bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "Test has next",
+			fields: fields{
+				chunks:   []string{"chunk1", "chunk2"},
+				position: 0,
+			},
+			want: true,
+		},
+		{
+			name: "Test has no next",
+			fields: fields{
+				chunks:   []string{"chunk1", "chunk2"},
+				position: 1,
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -37,8 +52,26 @@ func TestArrayChunkIterator_next(t *testing.T) {
 		name   string
 		fields fields
 		want   string
+		want1  bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "Test get existing next",
+			fields: fields{
+				chunks:   []string{"chunk1", "chunk2"},
+				position: 0,
+			},
+			want:  "chunk2",
+			want1: true,
+		},
+		{
+			name: "Test fail when there is no next",
+			fields: fields{
+				chunks:   []string{"chunk1", "chunk2"},
+				position: 1,
+			},
+			want:  "",
+			want1: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,7 +79,9 @@ func TestArrayChunkIterator_next(t *testing.T) {
 				chunks:   tt.fields.chunks,
 				position: tt.fields.position,
 			}
-			assert.Equalf(t, tt.want, i.next(), "next()")
+			got, got1 := i.next()
+			assert.Equalf(t, tt.want, got, "next()")
+			assert.Equalf(t, tt.want1, got1, "next()")
 		})
 	}
 }
@@ -60,7 +95,13 @@ func TestNewArrayChunkIterator(t *testing.T) {
 		args args
 		want ArrayChunkIterator
 	}{
-		// TODO: Add test cases.
+		{
+			name: "Create new ArrayChunkIterator",
+			args: args{
+				chunks: []string{"chunk1", "chunk2"},
+			},
+			want: ArrayChunkIterator{chunks: []string{"chunk1", "chunk2"}, position: -1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hubclient/rapid-scans-client.go
+++ b/hubclient/rapid-scans-client.go
@@ -35,7 +35,7 @@ const (
 
 type ChunkIterator interface {
 	hasNext() bool
-	next() (string, bool)
+	next() (string, error)
 }
 
 func (c *Client) StartRapidScan(bdioHeaderContent string) (error, string) {
@@ -61,16 +61,12 @@ func (c *Client) UploadBdioFilesByChunk(bdioUploadEndpoint string, chunkCount in
 	header.Add(headerBdDocumentCount, strconv.Itoa(chunkCount))
 
 	for iterator.hasNext() {
-		bdioContent, found := iterator.next()
-		if found {
-			err := c.HttpPutStringWithHeader(bdioUploadEndpoint, bdioContent, hubapi.ContentTypeRapidScanRequest, http.StatusAccepted, header)
-			if err != nil {
-				log.Error("Error uploading bdio files.", err)
-				return err
-			}
-		} else {
-			log.Error("Unable to retrieve next chunk")
-			return errors.New("unable to retrieve next chunk")
+		bdioContent, err := iterator.next()
+
+		err = c.HttpPutStringWithHeader(bdioUploadEndpoint, bdioContent, hubapi.ContentTypeRapidScanRequest, http.StatusAccepted, header)
+		if err != nil {
+			log.Error("Error uploading bdio files.", err)
+			return err
 		}
 	}
 

--- a/hubclient/rapid-scans-client.go
+++ b/hubclient/rapid-scans-client.go
@@ -52,10 +52,10 @@ func (c *Client) StartRapidScan(bdioHeaderContent string) (error, string) {
 
 func (c *Client) UploadBdioFiles(bdioUploadEndpoint string, bdioContents []string) error {
 	iterator := NewArrayChunkIterator(bdioContents)
-	return c.UpdateBdioFilesByChunk(bdioUploadEndpoint, len(bdioContents), &iterator)
+	return c.UploadBdioFilesByChunk(bdioUploadEndpoint, len(bdioContents), &iterator)
 }
 
-func (c *Client) UpdateBdioFilesByChunk(bdioUploadEndpoint string, chunkCount int, iterator ChunkIterator) error {
+func (c *Client) UploadBdioFilesByChunk(bdioUploadEndpoint string, chunkCount int, iterator ChunkIterator) error {
 	header := http.Header{}
 	header.Add(headerBdMode, bdModeAppend)
 	header.Add(headerBdDocumentCount, strconv.Itoa(chunkCount))


### PR DESCRIPTION
This change introduces the concept of a ChunkProvider which can be used to supply BDIO chunks, one at a time, to be uploaded. This has the advantage that all chunks do not have to be read into memory first which may not be possible for large scans.