### PR TITLE
expose ChunkIterator interface methods

### DIFF
--- a/hubclient/array-chunk-iterator.go
+++ b/hubclient/array-chunk-iterator.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Synopsys, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hubclient
 
 import "github.com/pkg/errors"
@@ -14,7 +28,7 @@ func NewArrayChunkIterator(chunks []string) ArrayChunkIterator {
 	return *i
 }
 
-func (i *ArrayChunkIterator) hasNext() bool {
+func (i *ArrayChunkIterator) HasNext() bool {
 	if len(i.chunks) > (i.position + 1) {
 		return true
 	} else {
@@ -22,8 +36,8 @@ func (i *ArrayChunkIterator) hasNext() bool {
 	}
 }
 
-// next returns true and the next chunk if there is a next chunk. Returns false otherwise.
-func (i *ArrayChunkIterator) next() (string, error) {
+// Next returns true and the next chunk if there is a next chunk. Returns false otherwise.
+func (i *ArrayChunkIterator) Next() (string, error) {
 	i.position++
 	if i.position < len(i.chunks) {
 		return i.chunks[i.position], nil

--- a/hubclient/array-chunk-iterator_test.go
+++ b/hubclient/array-chunk-iterator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Synopsys, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hubclient
 
 import (
@@ -6,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestArrayChunkIterator_hasNext(t *testing.T) {
+func TestArrayChunkIterator_HasNext(t *testing.T) {
 	type fields struct {
 		chunks   []string
 		position int
@@ -39,12 +53,12 @@ func TestArrayChunkIterator_hasNext(t *testing.T) {
 				chunks:   tt.fields.chunks,
 				position: tt.fields.position,
 			}
-			assert.Equalf(t, tt.want, i.hasNext(), "hasNext()")
+			assert.Equalf(t, tt.want, i.HasNext(), "HasNext()")
 		})
 	}
 }
 
-func TestArrayChunkIterator_next(t *testing.T) {
+func TestArrayChunkIterator_Next(t *testing.T) {
 	type fields struct {
 		chunks   []string
 		position int
@@ -80,11 +94,11 @@ func TestArrayChunkIterator_next(t *testing.T) {
 				chunks:   tt.fields.chunks,
 				position: tt.fields.position,
 			}
-			got, err := i.next()
-			if !tt.wantErr(t, err, fmt.Sprintf("next()")) {
+			got, err := i.Next()
+			if !tt.wantErr(t, err, fmt.Sprintf("Next()")) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "next()")
+			assert.Equalf(t, tt.want, got, "Next()")
 		})
 	}
 }

--- a/hubclient/rapid-scans-client.go
+++ b/hubclient/rapid-scans-client.go
@@ -34,8 +34,8 @@ const (
 )
 
 type ChunkIterator interface {
-	hasNext() bool
-	next() (string, error)
+	HasNext() bool
+	Next() (string, error)
 }
 
 func (c *Client) StartRapidScan(bdioHeaderContent string) (error, string) {
@@ -60,8 +60,8 @@ func (c *Client) UploadBdioFilesByChunk(bdioUploadEndpoint string, chunkCount in
 	header.Add(headerBdMode, bdModeAppend)
 	header.Add(headerBdDocumentCount, strconv.Itoa(chunkCount))
 
-	for iterator.hasNext() {
-		bdioContent, err := iterator.next()
+	for iterator.HasNext() {
+		bdioContent, err := iterator.Next()
 
 		err = c.HttpPutStringWithHeader(bdioUploadEndpoint, bdioContent, hubapi.ContentTypeRapidScanRequest, http.StatusAccepted, header)
 		if err != nil {


### PR DESCRIPTION
The recently added ChunkIterator interface allows callers to decide how chunks are uploaded. However, the interface is not currently exposing critical methods so using it outside of its package is not possible. This work exposes those methods so any caller can use the interface.