### PR TITLE
Add licenseFamilyName field to ComponentLicenceV2

### DIFF
--- a/hubapi/rapid-scans-api.go
+++ b/hubapi/rapid-scans-api.go
@@ -111,4 +111,5 @@ type ComponentLicenceV2 struct {
 	SpdxId         *string              `json:"spdxId"`
 	Licenses       []ComponentLicenceV2 `json:"licenses"`
 	Ownership      string               `json:"ownership"`
+	FamilyName     string               `json:"licenseFamilyName"`
 }


### PR DESCRIPTION
A new field was added to the licenses as part of HUB-36947