### PR TITLE
update gock import to make hub-client-go module easier to import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module github.com/blackducksoftware/hub-client-go
 go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/h2non/gock v1.0.14
-	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 // indirect
+	gopkg.in/h2non/gock.v1 v1.0.14
 )
 
-replace github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 // indirect
+)

--- a/hubclient/apitoken-client_test.go
+++ b/hubclient/apitoken-client_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/h2non/gock"
+	"gopkg.in/h2non/gock.v1"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
In an effort to resolve issue #90 

updates the `gock` import to not require the replace parameter in the `go.mod` which needs to be added to all consumers of this module if they want to import it.

`go mod tidy` reorganized the `go.mod` file